### PR TITLE
added save-as, added saving files as .cw format, kept txt compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ python coPywork.py [/path/to/file.txt]
 - Ctrl + S: Save the current file
 - Ctrl + M: Toggle between Edit Mode & Practice Mode
 
+## Save format
+- coPywork files are saved as a zip archive with a .cw extension
+- The .cw files contain the text content as well as copying progress & statistics
+- If you wish to access the text content as a .txt file, simply unzip the .cw file and look for `content.txt`
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/coPywork.py
+++ b/coPywork.py
@@ -24,18 +24,24 @@ last_typed_time = None  # Time of last keystroke
 is_typing_active = False  # Flag to track if typing is currently active
 current_file_path = None  # Track the currently open file
 
+def handle_file_save(file_path):
+    """Helper to check file extension and save using the correct method."""
+    global current_file_path
+    current_file_path = file_path
+    if current_file_path.lower().endswith('.txt'):
+        save_to_txt_file(current_file_path)
+    else:
+        # Add .cw extension if not present and not a .txt file
+        if not current_file_path.lower().endswith('.cw'):
+            current_file_path += '.cw'
+        save_to_cw_file(current_file_path)
+
 def save_file():
     global current_file_path
     
     # If we already have a file path, save directly to it
     if current_file_path:
-        # Check file extension to determine save method
-        if current_file_path.lower().endswith('.txt'):
-            # Use legacy save method for .txt files
-            save_to_txt_file(current_file_path)
-        else:
-            # Use new .cw format for other files
-            save_to_cw_file(current_file_path)
+        handle_file_save(current_file_path)
     else:
         # No current file, prompt for a location
         file_path = filedialog.asksaveasfilename(
@@ -43,15 +49,7 @@ def save_file():
             filetypes=[("CoPywork files", "*.cw"), ("Text files", "*.txt"), ("All files", "*.*")]
         )
         if file_path:
-            current_file_path = file_path
-            # Check file extension to determine save method
-            if current_file_path.lower().endswith('.txt'):
-                save_to_txt_file(current_file_path)
-            else:
-                # Add .cw extension if not present and not a .txt file
-                if not current_file_path.lower().endswith('.cw'):
-                    current_file_path += '.cw'
-                save_to_cw_file(current_file_path)
+            handle_file_save(file_path)
 
 def save_to_cw_file(file_path):
     """Save text content and color data to a .cw zip archive"""
@@ -405,17 +403,7 @@ def save_as_file():
     )
     
     if file_path:
-        # Update the current file path
-        current_file_path = file_path
-        
-        # Check file extension to determine save method
-        if current_file_path.lower().endswith('.txt'):
-            save_to_txt_file(current_file_path)
-        else:
-            # Add .cw extension if not present and not a .txt file
-            if not current_file_path.lower().endswith('.cw'):
-                current_file_path += '.cw'
-            save_to_cw_file(current_file_path)
+        handle_file_save(file_path)
 
 app = tk.Tk()
 app.title("coPywork")


### PR DESCRIPTION
-added the save-as option to the file menu
-added functionality to save the progress data & text content in the save file with a .cw extension.
    -.cw files are .zip archives
    -.cw files contain content.txt & colors.json
-kept .txt compatability
    -if a file with .txt extension is opened with coPywork, when it is saved, it will still be saved as .txt
    -when this happens, an additional json formatted file, <file>.txt.colors, will be saved along side the original .txt file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `.cw` file format that saves your work as a zip archive, storing both text content and color tags in a single file.
  - Added "Save As" functionality, allowing you to save your work under a new name or format.
  - Enhanced file dialogs to support both `.cw` and `.txt` formats.

- **Bug Fixes**
  - Improved error handling for file operations with user-friendly messages.

- **Documentation**
  - Updated README with details about the new save format and instructions for accessing content within `.cw` files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->