### PR TITLE
Combine saved files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ python coPywork.py [/path/to/file.txt]
 - Ctrl + S: Save the current file
 - Ctrl + M: Toggle between Edit Mode & Practice Mode
 
+## Save format
+- coPywork files are saved as a zip archive with a .cw extension
+- The .cw files contain the text content as well as copying progress & statistics
+- If you wish to access the text content as a .txt file, simply unzip the .cw file and look for `content.txt`
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/coPywork.py
+++ b/coPywork.py
@@ -24,18 +24,24 @@ last_typed_time = None  # Time of last keystroke
 is_typing_active = False  # Flag to track if typing is currently active
 current_file_path = None  # Track the currently open file
 
+def handle_file_save(file_path):
+    """Helper to check file extension and save using the correct method."""
+    global current_file_path
+    current_file_path = file_path
+    if current_file_path.lower().endswith('.txt'):
+        save_to_txt_file(current_file_path)
+    else:
+        # Add .cw extension if not present and not a .txt file
+        if not current_file_path.lower().endswith('.cw'):
+            current_file_path += '.cw'
+        save_to_cw_file(current_file_path)
+
 def save_file():
     global current_file_path
     
     # If we already have a file path, save directly to it
     if current_file_path:
-        # Check file extension to determine save method
-        if current_file_path.lower().endswith('.txt'):
-            # Use legacy save method for .txt files
-            save_to_txt_file(current_file_path)
-        else:
-            # Use new .cw format for other files
-            save_to_cw_file(current_file_path)
+        handle_file_save(current_file_path)
     else:
         # No current file, prompt for a location
         file_path = filedialog.asksaveasfilename(
@@ -43,15 +49,7 @@ def save_file():
             filetypes=[("CoPywork files", "*.cw"), ("Text files", "*.txt"), ("All files", "*.*")]
         )
         if file_path:
-            current_file_path = file_path
-            # Check file extension to determine save method
-            if current_file_path.lower().endswith('.txt'):
-                save_to_txt_file(current_file_path)
-            else:
-                # Add .cw extension if not present and not a .txt file
-                if not current_file_path.lower().endswith('.cw'):
-                    current_file_path += '.cw'
-                save_to_cw_file(current_file_path)
+            handle_file_save(file_path)
 
 def save_to_cw_file(file_path):
     """Save text content and color data to a .cw zip archive"""
@@ -405,17 +403,7 @@ def save_as_file():
     )
     
     if file_path:
-        # Update the current file path
-        current_file_path = file_path
-        
-        # Check file extension to determine save method
-        if current_file_path.lower().endswith('.txt'):
-            save_to_txt_file(current_file_path)
-        else:
-            # Add .cw extension if not present and not a .txt file
-            if not current_file_path.lower().endswith('.cw'):
-                current_file_path += '.cw'
-            save_to_cw_file(current_file_path)
+        handle_file_save(file_path)
 
 app = tk.Tk()
 app.title("coPywork")

--- a/coPywork.py
+++ b/coPywork.py
@@ -51,6 +51,29 @@ def save_file():
         if file_path:
             handle_file_save(file_path)
 
+def collect_color_data():
+    """Helper function to collect color tag ranges from the text area"""
+    color_data = {
+        "correct": [],
+        "incorrect": []
+    }
+    
+    # Get all ranges with "correct" tag
+    correct_ranges = text_area.tag_ranges("correct")
+    for i in range(0, len(correct_ranges), 2):
+        start = text_area.index(correct_ranges[i])
+        end = text_area.index(correct_ranges[i+1])
+        color_data["correct"].append((start, end))
+    
+    # Get all ranges with "incorrect" tag
+    incorrect_ranges = text_area.tag_ranges("incorrect")
+    for i in range(0, len(incorrect_ranges), 2):
+        start = text_area.index(incorrect_ranges[i])
+        end = text_area.index(incorrect_ranges[i+1])
+        color_data["incorrect"].append((start, end))
+    
+    return color_data
+
 def save_to_cw_file(file_path):
     """Save text content and color data to a .cw zip archive"""
     try:
@@ -61,25 +84,8 @@ def save_to_cw_file(file_path):
             with open(text_file_path, 'w', encoding='utf-8') as text_file:
                 text_file.write(text_area.get(1.0, tk.END))
             
-            # Prepare color data
-            color_data = {
-                "correct": [],
-                "incorrect": []
-            }
-            
-            # Get all ranges with "correct" tag
-            correct_ranges = text_area.tag_ranges("correct")
-            for i in range(0, len(correct_ranges), 2):
-                start = text_area.index(correct_ranges[i])
-                end = text_area.index(correct_ranges[i+1])
-                color_data["correct"].append((start, end))
-            
-            # Get all ranges with "incorrect" tag
-            incorrect_ranges = text_area.tag_ranges("incorrect")
-            for i in range(0, len(incorrect_ranges), 2):
-                start = text_area.index(incorrect_ranges[i])
-                end = text_area.index(incorrect_ranges[i+1])
-                color_data["incorrect"].append((start, end))
+            # Collect color data using the helper function
+            color_data = collect_color_data()
             
             # Save color data to a temporary file
             color_file_path = os.path.join(temp_dir, "colors.json")
@@ -104,25 +110,8 @@ def save_to_txt_file(file_path):
         with open(file_path, 'w', encoding='utf-8') as text_file:
             text_file.write(text_area.get(1.0, tk.END))
         
-        # Prepare color data
-        color_data = {
-            "correct": [],
-            "incorrect": []
-        }
-        
-        # Get all ranges with "correct" tag
-        correct_ranges = text_area.tag_ranges("correct")
-        for i in range(0, len(correct_ranges), 2):
-            start = text_area.index(correct_ranges[i])
-            end = text_area.index(correct_ranges[i+1])
-            color_data["correct"].append((start, end))
-        
-        # Get all ranges with "incorrect" tag
-        incorrect_ranges = text_area.tag_ranges("incorrect")
-        for i in range(0, len(incorrect_ranges), 2):
-            start = text_area.index(incorrect_ranges[i])
-            end = text_area.index(incorrect_ranges[i+1])
-            color_data["incorrect"].append((start, end))
+        # Collect color data using the helper function
+        color_data = collect_color_data()
         
         # Save color data to a companion file
         color_file_path = file_path + ".colors"

--- a/coPywork.py
+++ b/coPywork.py
@@ -170,6 +170,12 @@ def open_cw_file(file_path):
         with tempfile.TemporaryDirectory() as temp_dir:
             # Extract the zip archive
             with zipfile.ZipFile(file_path, 'r') as zip_file:
+                # Validate required files exist
+                file_list = zip_file.namelist()
+                if 'content.txt' not in file_list:
+                    raise ValueError("Invalid .cw file: missing content.txt")
+                if 'colors.json' not in file_list:
+                    raise ValueError("Invalid .cw file: missing colors.json")
                 zip_file.extractall(temp_dir)
             
             # Load text content
@@ -194,6 +200,9 @@ def open_cw_file(file_path):
         # Set the current file path
         current_file_path = file_path
     
+    except ValueError as e:
+        # Handle validation errors specifically
+        messagebox.showerror("Invalid File", str(e))
     except Exception as e:
         messagebox.showerror("Error", f"Error opening .cw file: {str(e)}")
 

--- a/coPywork.py
+++ b/coPywork.py
@@ -269,8 +269,10 @@ def check_typing_activity():
             # Pause the session timer
             is_typing_active = False
             # remove previous 5 seconds from the duration
-            if session_typing_duration <= 5:
+            if session_typing_duration >= 5:
                 session_typing_duration -= 5
+            else:
+                session_typing_duration = 0
         elif session_start_time:
             session_typing_duration += 1
             # Don't reset session_start_time so we can resume


### PR DESCRIPTION
-added the save-as option to the file menu
-added functionality to save the progress data & text content in the save file with a .cw extension.
-.cw files are .zip archives
-.cw files contain content.txt & colors.json
-kept .txt compatability
-if a file with .txt extension is opened with coPywork, when it is saved, it will still be saved as .txt
-when this happens, an additional json formatted file, .txt.colors, will be saved along side the original .txt file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for a new ".cw" file format, allowing users to save both text content and color tags in a single archive.
  - Added a "Save As" option for saving content under a new filename with either ".cw" or ".txt" formats.
  - File dialogs now explicitly filter for ".cw" and ".txt" files.

- **Documentation**
  - Updated the README to explain the new ".cw" save format and how to access text content within these files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->